### PR TITLE
REL #1 preloaded_card_loading: Apply justify to ljust

### DIFF
--- a/preloaded_card_loading.txt
+++ b/preloaded_card_loading.txt
@@ -1,3 +1,3 @@
 {% for record in records %}\
-${justify(record.card_number, 16)}${format_decimal(record.amount)}${justify(strip_accents(record.description), 34)}
+${record.card_number}${format_decimal(record.amount)}${justify(strip_accents(record.description), 60)}
 {% end %}\

--- a/statement.py
+++ b/statement.py
@@ -543,8 +543,8 @@ class PreloadedCardLoadingReport(Report):
         CardLoading = pool.get('account.preloaded_card.loading')
 
         def justify(string, size):
-            #return string[:size].ljust(size)
-            return string[:size]
+            return string.ljust(size)
+            # return string[:size]
 
         def format_decimal(n):
             if not isinstance(n, Decimal):


### PR DESCRIPTION
The line must has 85 characters in total.

- Remove justify to record.card_number.
- Set justify to 60 characters in record.description.